### PR TITLE
Inventory screen

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -38,6 +38,7 @@ project/assembly_name="ink-orporated"
 
 Player=""
 rebind_button=""
+item_description=""
 
 [input]
 

--- a/src/clues/clue_description.tscn
+++ b/src/clues/clue_description.tscn
@@ -1,53 +1,54 @@
-[gd_scene load_steps=3 format=3 uid="uid://dnbdtetmksjia"]
+[gd_scene load_steps=5 format=3 uid="uid://dnbdtetmksjia"]
 
 [ext_resource type="Texture2D" uid="uid://eu0kdjsoh565" path="res://assets/sprites/gridcell border.png" id="1_m40gr"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_2e5o7"]
-size = Vector2(177.813, 177.438)
+size = Vector2(177.813, 219.445)
+
+[sub_resource type="LabelSettings" id="LabelSettings_3xtir"]
+font_size = 19
+
+[sub_resource type="LabelSettings" id="LabelSettings_1imky"]
+font_size = 14
 
 [node name="Description" type="Area2D" groups=["item_description"]]
-position = Vector2(-96, 90)
+position = Vector2(-121, 119)
+scale = Vector2(1.28, 1.28)
 
 [node name="Panel" type="Panel" parent="."]
-offset_left = 6.14281
-offset_top = -182.296
-offset_right = 46.1428
-offset_bottom = -142.296
+offset_left = 6.0
+offset_top = -203.0
+offset_right = 46.0
+offset_bottom = -154.0
 scale = Vector2(4.40702, 4.51794)
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(94, -92)
+scale = Vector2(1, 1.25)
 texture = ExtResource("1_m40gr")
 
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(94.0938, -93.0556)
+shape = SubResource("RectangleShape2D_2e5o7")
+debug_color = Color(0, 0.6, 0.7, 0.42)
+
 [node name="NameLabel" type="Label" parent="."]
-offset_left = 71.8571
-offset_top = -177.086
-offset_right = 122.857
-offset_bottom = -154.086
+offset_left = 69.0
+offset_top = -178.0
+offset_right = 130.0
+offset_bottom = -151.0
 scale = Vector2(0.885714, 0.885714)
 text = "Name:"
+label_settings = SubResource("LabelSettings_3xtir")
 horizontal_alignment = 1
 
 [node name="DescriptionLabel" type="Label" parent="."]
-offset_left = 59.7143
-offset_top = -152.197
-offset_right = 148.714
-offset_bottom = -129.197
+offset_left = 6.0
+offset_top = -148.0
+offset_right = 208.0
+offset_bottom = -8.00002
 scale = Vector2(0.885714, 0.885714)
-text = "Description"
+text = "WRITING RANDOM FILLER DESCRIPTION WRITING RANDOM FILLER DESCRIPTION WRITING RANDOM FILLER DESCRIPTION "
+label_settings = SubResource("LabelSettings_1imky")
 horizontal_alignment = 1
-
-[node name="Icon" type="Label" parent="."]
-offset_left = 51.1428
-offset_top = -114.574
-offset_right = 157.143
-offset_bottom = -65.5739
-scale = Vector2(0.885714, 0.885714)
-text = "IMAGE IMAGE
-IMAGE IMAGE"
-horizontal_alignment = 1
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(94.0938, -90.7188)
-shape = SubResource("RectangleShape2D_2e5o7")
-debug_color = Color(0, 0.6, 0.7, 0.42)
+autowrap_mode = 3

--- a/src/clues/clue_description.tscn
+++ b/src/clues/clue_description.tscn
@@ -1,19 +1,12 @@
-[gd_scene load_steps=3 format=3 uid="uid://q7ux5fjcblwo"]
+[gd_scene load_steps=3 format=3 uid="uid://dnbdtetmksjia"]
 
-[ext_resource type="Texture2D" uid="uid://eu0kdjsoh565" path="res://assets/sprites/gridcell border.png" id="1_hmd85"]
+[ext_resource type="Texture2D" uid="uid://eu0kdjsoh565" path="res://assets/sprites/gridcell border.png" id="1_m40gr"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_ugmg3"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_2e5o7"]
 size = Vector2(177.813, 177.438)
 
-[node name="ClueDescription" type="Node2D"]
-position = Vector2(1, -2)
-
-[node name="Area2D" type="Area2D" parent="."]
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-position = Vector2(94.0938, -90.7188)
-shape = SubResource("RectangleShape2D_ugmg3")
-debug_color = Color(0, 0.6, 0.7, 0.42)
+[node name="Description" type="Area2D" groups=["item_description"]]
+position = Vector2(-96, 90)
 
 [node name="Panel" type="Panel" parent="."]
 offset_left = 6.14281
@@ -24,7 +17,7 @@ scale = Vector2(4.40702, 4.51794)
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(94, -92)
-texture = ExtResource("1_hmd85")
+texture = ExtResource("1_m40gr")
 
 [node name="NameLabel" type="Label" parent="."]
 offset_left = 71.8571
@@ -53,3 +46,8 @@ scale = Vector2(0.885714, 0.885714)
 text = "IMAGE IMAGE
 IMAGE IMAGE"
 horizontal_alignment = 1
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(94.0938, -90.7188)
+shape = SubResource("RectangleShape2D_2e5o7")
+debug_color = Color(0, 0.6, 0.7, 0.42)

--- a/src/clues/clue_description.tscn
+++ b/src/clues/clue_description.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=3 format=3 uid="uid://q7ux5fjcblwo"]
+
+[ext_resource type="Texture2D" uid="uid://eu0kdjsoh565" path="res://assets/sprites/gridcell border.png" id="1_hmd85"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_ugmg3"]
+size = Vector2(177.813, 177.438)
+
+[node name="ClueDescription" type="Node2D"]
+position = Vector2(1, -2)
+
+[node name="Area2D" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+position = Vector2(94.0938, -90.7188)
+shape = SubResource("RectangleShape2D_ugmg3")
+debug_color = Color(0, 0.6, 0.7, 0.42)
+
+[node name="Panel" type="Panel" parent="."]
+offset_left = 6.14281
+offset_top = -182.296
+offset_right = 46.1428
+offset_bottom = -142.296
+scale = Vector2(4.40702, 4.51794)
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(94, -92)
+texture = ExtResource("1_hmd85")
+
+[node name="NameLabel" type="Label" parent="."]
+offset_left = 71.8571
+offset_top = -177.086
+offset_right = 122.857
+offset_bottom = -154.086
+scale = Vector2(0.885714, 0.885714)
+text = "Name:"
+horizontal_alignment = 1
+
+[node name="DescriptionLabel" type="Label" parent="."]
+offset_left = 59.7143
+offset_top = -152.197
+offset_right = 148.714
+offset_bottom = -129.197
+scale = Vector2(0.885714, 0.885714)
+text = "Description"
+horizontal_alignment = 1
+
+[node name="Icon" type="Label" parent="."]
+offset_left = 51.1428
+offset_top = -114.574
+offset_right = 157.143
+offset_bottom = -65.5739
+scale = Vector2(0.885714, 0.885714)
+text = "IMAGE IMAGE
+IMAGE IMAGE"
+horizontal_alignment = 1

--- a/src/clues/clue_description.tscn
+++ b/src/clues/clue_description.tscn
@@ -12,6 +12,7 @@ font_size = 19
 font_size = 14
 
 [node name="Description" type="Area2D" groups=["item_description"]]
+z_index = 3
 position = Vector2(-121, 119)
 scale = Vector2(1.28, 1.28)
 

--- a/src/clues/clue_grid_menu.gd
+++ b/src/clues/clue_grid_menu.gd
@@ -11,13 +11,16 @@ extends Node2D
 @onready var grid_cell_scene: PackedScene = preload("res://src/clues/grid_cell.tscn")
 @onready var panel_scene: PackedScene = preload("res://src/clues/clue_panel.tscn")
 
+var inventory_size: int = 3 # Number of rows inventory will have
 var player_clues: Array[Clue] = []
 
-var grid_cells: Array[GridBox] = []
+var clue_grid_cells: Array[GridBox] = []
+var item_grid_cells: Array[GridBox] = []
 var panels: Array[CluePanel] = []
 
 const PANEL_SIZE: int = 184
-const INITIAL_POSITION: Vector2 = Vector2(200, 200)
+const INITIAL_POSITION: Vector2 = Vector2(1500, 200)
+const INITIAL_ITEM_POSITION: Vector2 = Vector2(150,200)
 const OFFSET: Vector2 = Vector2(200, 200)
 
 signal puzzle_solved
@@ -44,12 +47,33 @@ func _process(delta: float) -> void:
 
 
 func populate_clue_panels():
+	
 	for clue in player_clues:
 		var panelInst = panel_scene.instantiate()
 		panelInst.clue = clue
 		$Panels.add_child(panelInst)
 		panels.append(panelInst)
 		panelInst.numberLabel.text = str(clue.correct_panel)
+		
+	var rows := inventory_size
+	# it's always two for now
+	var cols = 2
+	var i = 0
+	for r in rows:
+		for c in cols:
+			var gridCellInst: GridBox = grid_cell_scene.instantiate()
+			gridCellInst.id = i
+			gridCellInst.position.x = INITIAL_ITEM_POSITION.x + (OFFSET.x * c)
+			gridCellInst.position.y = INITIAL_ITEM_POSITION.y + (OFFSET.y * r)
+			$GridCells.add_child(gridCellInst)
+			item_grid_cells.append(gridCellInst)
+			i += 1
+	i = 0
+	for cell in item_grid_cells:
+		if !panels.is_empty() && i < panels.size():
+			panels[i].position.x = cell.position.x
+			panels[i].position.y = cell.position.y
+			i += 1
 
 
 func populate_grid_cells():
@@ -64,7 +88,7 @@ func populate_grid_cells():
 			gridCellInst.position.x = INITIAL_POSITION.x + (OFFSET.x * c)
 			gridCellInst.position.y = INITIAL_POSITION.y + (OFFSET.y * r)
 			$GridCells.add_child(gridCellInst)
-			grid_cells.append(gridCellInst)
+			clue_grid_cells.append(gridCellInst)
 			gridCellInst.numberLabel.text = str(i)
 			i += 1
 			if i == player_clues.size():
@@ -73,8 +97,9 @@ func populate_grid_cells():
 			break
 
 
+
 func panels_correct() -> bool:
-	for grid_cell in grid_cells:
+	for grid_cell in clue_grid_cells:
 		if not grid_cell.correct_panel:
 			return false
 	return true

--- a/src/clues/panel.gd
+++ b/src/clues/panel.gd
@@ -14,6 +14,8 @@ var _is_selected: bool = false
 var _grids_inside: Array[GridBox] = []
 
 var panel_exists: bool = false
+var delay: float = 0.5
+var time_elapsed: float = 0.0
 var desc_panel
 const OFFSET: Vector2 = Vector2(80, 30)
 
@@ -35,11 +37,13 @@ func _ready() -> void:
 
 
 func _process(delta: float) -> void:
-	if _is_mouse_in:
-		await get_tree().create_timer(0.5).timeout
-		if(!panel_exists):
+	if _is_mouse_in and !_is_selected:
+		time_elapsed += delta
+		if(!panel_exists and time_elapsed > delay):
 			desc_panel = show_description()
-	if !_is_mouse_in:
+			time_elapsed = 0
+	if !_is_mouse_in or _is_selected:
+		time_elapsed = 0
 		if(panel_exists):
 			hide_description(desc_panel)
 	#Check if the grab button is being used

--- a/src/clues/panel.gd
+++ b/src/clues/panel.gd
@@ -28,6 +28,8 @@ func _ready() -> void:
 
 
 func _process(delta: float) -> void:
+	if _is_mouse_in:
+		
 	#Check if the grab button is being used
 	if Input.is_action_pressed("grab"):
 		#Set the panel to selected if the mouse is in the area 2D
@@ -85,3 +87,7 @@ func find_closest_box(boxes: Array[GridBox], pos: Vector2) -> GridBox:
 			closest_box = box
 			closest_position = closest_box.position.distance_to(pos)
 	return closest_box
+
+
+func show_description():
+	print("HOVERING")

--- a/src/clues/panel.gd
+++ b/src/clues/panel.gd
@@ -7,9 +7,15 @@ extends Area2D
 @onready var sprite: Sprite2D = $Sprite2D
 @onready var numberLabel: Label = $NumberLabel
 
+@onready var panel_desc_scene: PackedScene = preload("res://src/clues/clue_description.tscn")
+
 var _is_mouse_in: bool = false
 var _is_selected: bool = false
 var _grids_inside: Array[GridBox] = []
+
+var panel_exists: bool = false
+var desc_panel
+const OFFSET: Vector2 = Vector2(80, 30)
 
 static var _can_select: bool = true
 
@@ -29,7 +35,12 @@ func _ready() -> void:
 
 func _process(delta: float) -> void:
 	if _is_mouse_in:
-		
+		if(!panel_exists):
+			desc_panel = show_description()
+		print(desc_panel)
+	if !_is_mouse_in:
+		if(panel_exists):
+			hide_description(desc_panel)
 	#Check if the grab button is being used
 	if Input.is_action_pressed("grab"):
 		#Set the panel to selected if the mouse is in the area 2D
@@ -90,4 +101,14 @@ func find_closest_box(boxes: Array[GridBox], pos: Vector2) -> GridBox:
 
 
 func show_description():
-	print("HOVERING")
+	var panel_desc = panel_desc_scene.instantiate()
+	add_child(panel_desc)
+	panel_exists = true
+	panel_desc.position.x = OFFSET.x
+	panel_desc.position.y = OFFSET.y
+	return panel_desc
+	
+
+func hide_description(description: Area2D) -> void:
+	description.free()
+	panel_exists = false

--- a/src/clues/panel.gd
+++ b/src/clues/panel.gd
@@ -36,6 +36,7 @@ func _ready() -> void:
 
 func _process(delta: float) -> void:
 	if _is_mouse_in:
+		await get_tree().create_timer(0.5).timeout
 		if(!panel_exists):
 			desc_panel = show_description()
 	if !_is_mouse_in:

--- a/src/clues/panel.gd
+++ b/src/clues/panel.gd
@@ -26,6 +26,7 @@ func get_panel_name() -> String:
 
 func _ready() -> void:
 	sprite.texture = clue.panel
+	
 	area_entered.connect(_on_area_entered)
 	area_exited.connect(_on_area_exited)
 
@@ -37,7 +38,6 @@ func _process(delta: float) -> void:
 	if _is_mouse_in:
 		if(!panel_exists):
 			desc_panel = show_description()
-		print(desc_panel)
 	if !_is_mouse_in:
 		if(panel_exists):
 			hide_description(desc_panel)
@@ -103,6 +103,12 @@ func find_closest_box(boxes: Array[GridBox], pos: Vector2) -> GridBox:
 func show_description():
 	var panel_desc = panel_desc_scene.instantiate()
 	add_child(panel_desc)
+	
+	var nameLabel = panel_desc.find_child("NameLabel")
+	nameLabel.text = clue.name
+	var descriptionLabel = panel_desc.find_child("DescriptionLabel")
+	descriptionLabel.text = clue.desc
+	
 	panel_exists = true
 	panel_desc.position.x = OFFSET.x
 	panel_desc.position.y = OFFSET.y


### PR DESCRIPTION
- Hover over clues/items to see descriptions, 0.5s delay before the popup appears
- No keyboard usage yet for inventory navigation
- Spamming interaction key picks up multiple versions of the same item (Bug existed before this implementation)
- Created set number of slots for the inventory, can adjust size by changing `var inventory_size: int = 3` in the ``clue_grid_menu.gd`` script